### PR TITLE
Fix hyper-parameters typo

### DIFF
--- a/docs/llm.md
+++ b/docs/llm.md
@@ -29,7 +29,7 @@ llm_cfg = {
             # Use your own model service compatible with OpenAI API:
             # 'model': 'Qwen',
             # 'model_server': 'http://127.0.0.1:7905/v1',
-            # (Optional) LLM hyper-paramters:
+            # (Optional) LLM hyper-parameters:
             'generate_cfg': {
                 'top_p': 0.8
             }

--- a/docs/llm_cn.md
+++ b/docs/llm_cn.md
@@ -28,7 +28,7 @@ llm_cfg = {
             # Use your own model service compatible with OpenAI API:
             # 'model': 'Qwen',
             # 'model_server': 'http://127.0.0.1:7905/v1',
-            # (Optional) LLM hyper-paramters:
+            # (Optional) LLM hyper-parameters:
             'generate_cfg': {
                 'top_p': 0.8
             }

--- a/qwen_agent/llm/base.py
+++ b/qwen_agent/llm/base.py
@@ -108,7 +108,7 @@ class BaseChatModel(ABC):
             delta_stream: Whether to stream the response incrementally.
               (1) When False (recommended): Stream the full response every iteration.
               (2) When True: Stream the chunked response, i.e, delta responses.
-            extra_generate_cfg: Extra LLM generation hyper-paramters.
+            extra_generate_cfg: Extra LLM generation hyper-parameters.
 
         Returns:
             the generated message list response by llm.


### PR DESCRIPTION
## Summary
- fix `hyper-paramters` typo in docs
- fix same typo in `BaseChatModel.chat`

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*